### PR TITLE
Adding forced reload of GDM when playbook is run

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,6 +1,6 @@
 ansible_pull_url: https://github.com/Sentry-Interactive/kiosk-playbook.git
 ansible_pull_timer: |
   OnBootSec=5m
-  OnCalendar=daily
+  OnCalendar=*-*-* 05:00:00
   RandomizedDelaySec=30m
 hostname: "MA{{ ansible_default_ipv4.macaddress[-10:] | replace(':','') | upper | string }}"

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: Reload Systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -28,6 +28,8 @@
   loop:
     - ansible-pull.service
     - ansible-pull.timer
+  notify:
+    - Reload Systemd
 
 - name: Enable ansible-pull timer
   ansible.builtin.service:

--- a/roles/kiosk-gdm/tasks/main.yml
+++ b/roles/kiosk-gdm/tasks/main.yml
@@ -170,3 +170,9 @@
       gsettings set org.gnome.settings-daemon.plugins.power idle-dim false
   notify:
     - Restart GDM
+
+- name: Force restart of GDM
+  command: /bin/true
+  changed_when: true
+  notify:
+    - Restart GDM


### PR DESCRIPTION
Some of the kiosks are experiencing issues with the webcam disabling themselves after some days of operation, this is an attempt at a workaround by forcing a restart of GDM everyday at 5am UTC when the playbook is updated. 