### PR TITLE
change in mic name

### DIFF
--- a/roles/kiosk-gdm/files/startup
+++ b/roles/kiosk-gdm/files/startup
@@ -10,7 +10,7 @@ amixer set "Speaker" 70%
 
 
 #Make external microphone the primary device 
-DEVICE_NAME="USB_PnP_Audio_Device-00.mono"
+DEVICE_NAME="alsa_input.usb-0c76"
 if pacmd list-sources | grep -B 2  "$DEVICE_NAME"; then
         MIC_INDEX=$(pacmd list-sources | grep -B 2 "$DEVICE_NAME" | awk '/index:/ {print $2}')
         # Set default input device


### PR DESCRIPTION
we have found that some microphones have USB PNP  audio device and some Just USB audio device but the USB name and identification number doesn't seem to change
