### PR TITLE
Ensuring kiosk URL parameter is used in all places

### DIFF
--- a/roles/kiosk-frame/tasks/main.yml
+++ b/roles/kiosk-frame/tasks/main.yml
@@ -12,7 +12,7 @@
       - wpe-webkit-mir-kiosk
     options:
       - daemon=true
-      - url=https://sentry-kiosk-device.web.app/
+      - url={{ kiosk_ui_url }}
       - error-to-console=true
 
 - name: Snap Packages - Setup Plugs

--- a/roles/kiosk-gdm/files/chrome.json
+++ b/roles/kiosk-gdm/files/chrome.json
@@ -1,8 +1,0 @@
-{
-  "VideoCaptureAllowedUrls": [
-    "https://sentry-kiosk-device.web.app/"
-  ],
-  "AudioCaptureAllowedUrls": [
-    "https://sentry-kiosk-device.web.app/"
-  ]
-}

--- a/roles/kiosk-gdm/tasks/main.yml
+++ b/roles/kiosk-gdm/tasks/main.yml
@@ -93,9 +93,9 @@
     mode: '0755'
 
 - name: Setup Chromium managed policy
-  ansible.builtin.copy:
+  ansible.builtin.template:
     dest: /etc/chromium-browser/policies/managed/chrome.json
-    src: ../files/chrome.json
+    src: chrome.json
   notify:
     - Restart GDM
 
@@ -106,9 +106,9 @@
     mode: '0755'
 
 - name: Setup Firefox managed policy
-  ansible.builtin.copy:
+  ansible.builtin.template:
     dest: /etc/firefox/policies/policies.json
-    src: ../files/policies.json
+    src: policies.json
   notify:
     - Restart GDM
 

--- a/roles/kiosk-gdm/templates/chrome.json
+++ b/roles/kiosk-gdm/templates/chrome.json
@@ -1,0 +1,8 @@
+{
+  "VideoCaptureAllowedUrls": [
+    "{{ kiosk_ui_url }}"
+  ],
+  "AudioCaptureAllowedUrls": [
+    "{{ kiosk_ui_url }}"
+  ]
+}

--- a/roles/kiosk-gdm/templates/policies.json
+++ b/roles/kiosk-gdm/templates/policies.json
@@ -2,17 +2,17 @@
   "policies": {
     "Permissions": {
       "Camera": {
-        "Allow": ["https://sentry-kiosk-device.web.app"],
+        "Allow": ["{{ kiosk_ui_url }}"],
         "BlockNewRequests": true,
         "Locked": true
       },
       "Microphone": {
-        "Allow": ["https://sentry-kiosk-device.web.app"],
+        "Allow": ["{{ kiosk_ui_url }}"],
         "BlockNewRequests": true,
         "Locked": true
       },
       "Location": {
-        "Allow": ["https://sentry-kiosk-device.web.app"],
+        "Allow": ["{{ kiosk_ui_url }}"],
         "BlockNewRequests": false,
         "Locked": true
       },
@@ -21,7 +21,7 @@
         "Locked": true
       },
       "Autoplay": {
-        "Allow": ["https://sentry-kiosk-device.web.app"],
+        "Allow": ["{{ kiosk_ui_url }}"],
         "Default": "allow-audio-video",
         "Locked": true
       },


### PR DESCRIPTION
Switching hardcoded URLs to use `kiosk_ui_url`