### PR TITLE
Adding rotate script for new devices using HDMI-2 output

### DIFF
--- a/roles/kiosk_gdm/files/rotate
+++ b/roles/kiosk_gdm/files/rotate
@@ -13,6 +13,8 @@ then
             echo $i
             xinput set-prop "$i" --type=float "Coordinate Transformation Matrix" 0 -1 1 1 0 0 0 0 1
     done
+elif xrandr --listactivemonitors | grep -q "HDMI-2";
+  xrandr -o right
 else
   echo "Unable to find expected output device, ignoring rotation"
 fi


### PR DESCRIPTION
Quick and dirty approach to rotating the screen on new devices which use HDMI-2 as their main output.