### PR TITLE
Disabling PulseAudio suspension on idle

### DIFF
--- a/roles/kiosk_gdm/tasks/main.yml
+++ b/roles/kiosk_gdm/tasks/main.yml
@@ -191,6 +191,14 @@
   notify:
     - Restart GDM
 
+- name: Disable PulseAudio idle suspend
+  ansible.builtin.lineinfile:
+    dest: /etc/pulse/default.pa
+    regexp: '^load-module module-suspend-on-idle'
+    line: '#load-module module-suspend-on-idle'
+  notify:
+    - Restart GDM
+
 - name: Force restart of GDM
   ansible.builtin.command: /bin/true
   changed_when: true


### PR DESCRIPTION
We've seen a handful of instances where PulseAudio is crashing when nothing is happening, we suspect this is due to PulseAudio suspending itself so this PR disables `module-suspend-on-idle`. 