### PR TITLE
Ensuing Chromium snap is at latest refresh

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -1,6 +1,6 @@
 ---
-- hosts: all
-  name: Ansible-pull playbook to manage Sentry Interactive Kiosks
+- name: Ansible-pull playbook to manage Sentry Interactive Kiosks
+  hosts: all
   tasks:
     - name: Add hosts to inventory groups
       ansible.builtin.add_host:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,6 @@
 ---
-- hosts: all
-  name: Playbook to manage Sentry Interactive Kiosks
+- name: Playbook to manage Sentry Interactive Kiosks
+  hosts: all
   become: true
   roles:
     - role: common

--- a/roles/kiosk_gdm/defaults/main.yml
+++ b/roles/kiosk_gdm/defaults/main.yml
@@ -1,1 +1,2 @@
 kiosk_gdm_kiosk_ui_url: https://sentry-kiosk-device.web.app/
+kiosk_gdm_chromium_channel: latest/stable

--- a/roles/kiosk_gdm/files/kiosk.xsession
+++ b/roles/kiosk_gdm/files/kiosk.xsession
@@ -1,0 +1,6 @@
+[User]
+Session=kiosk-chromium
+SystemAccount=false
+
+[InputSource0]
+xkb=us

--- a/roles/kiosk_gdm/tasks/main.yml
+++ b/roles/kiosk_gdm/tasks/main.yml
@@ -26,6 +26,13 @@
       - alsa-utils
       - unclutter
 
+- name: Ensure Chromium is up to date
+  ansible.builtin.command: snap refresh chromium --channel="{{ kiosk_gdm_chromium_channel}}"
+  register: result
+  changed_when: '"has no updates available" not in result.stderr'
+  notify:
+    - Restart GDM
+
 - name: Configure GDM as default
   ansible.builtin.copy:
     dest: /etc/X11/default-display-manager
@@ -82,6 +89,9 @@
       [User]
       Session=kiosk-chromium
       SystemAccount=false
+      
+      [InputSource0]
+      xkb=us
   notify:
     - Restart GDM
 

--- a/roles/kiosk_gdm/tasks/main.yml
+++ b/roles/kiosk_gdm/tasks/main.yml
@@ -27,7 +27,7 @@
       - unclutter
 
 - name: Ensure Chromium is up to date
-  ansible.builtin.command: snap refresh chromium --channel="{{ kiosk_gdm_chromium_channel}}"
+  ansible.builtin.command: snap refresh chromium --channel="{{ kiosk_gdm_chromium_channel }}"
   register: result
   changed_when: '"has no updates available" not in result.stderr'
   notify:
@@ -81,17 +81,11 @@
 
 - name: Set Kiosk XSession as default
   ansible.builtin.copy:
+    src: files/kiosk.xsession
     dest: /var/lib/AccountsService/users/kiosk
     mode: '0600'
     owner: root
     group: root
-    content: |
-      [User]
-      Session=kiosk-chromium
-      SystemAccount=false
-      
-      [InputSource0]
-      xkb=us
   notify:
     - Restart GDM
 


### PR DESCRIPTION
Snaps don't seem to give much control over pinning a particular version, but we can control channel (e.g. stable or beta) through use of a variable and we can ensure we always have the latest installed, rather than leaving it to linger until an unknown snap refresh occurs.

Since the channel is a variable, it can be set on a per-kiosk basis for testing using host variables. 