### PR TITLE
Switching to Chromium stable and using systemctl to start PulseAudio

### DIFF
--- a/host_vars/MA811ABA5.yml
+++ b/host_vars/MA811ABA5.yml
@@ -1,2 +1,0 @@
----
-kiosk_gdm_chromium_channel: latest/stable

--- a/host_vars/MA9C1E4C2.yml
+++ b/host_vars/MA9C1E4C2.yml
@@ -1,2 +1,0 @@
----
-kiosk_gdm_chromium_channel: latest/stable

--- a/host_vars/MA9C1E7D1.yml
+++ b/host_vars/MA9C1E7D1.yml
@@ -1,2 +1,0 @@
----
-kiosk_gdm_chromium_channel: latest/stable

--- a/roles/kiosk_gdm/defaults/main.yml
+++ b/roles/kiosk_gdm/defaults/main.yml
@@ -1,3 +1,3 @@
 kiosk_gdm_kiosk_ui_url: https://sentry-kiosk-device.web.app/
-kiosk_gdm_chromium_channel: latest/beta
+kiosk_gdm_chromium_channel: latest/stable
 kiosk_gdm_xsession: kiosk-chromium

--- a/roles/kiosk_gdm/files/startup
+++ b/roles/kiosk_gdm/files/startup
@@ -2,7 +2,7 @@
 
 #Volume Control - turn up all volume output to 100%
 
-pulseaudio --start
+systemctl --user start pulseaudio
 
 amixer set "Master" 70%
 amixer set "Headphone" 70%


### PR DESCRIPTION
As the snap hold on Chromium will have now expired, we should switch back to stable so we have a relatively consistent setup; furthermore the current beta version has not shown to be anymore or less stable than the stable version.

In additional, the PR changes the way PulseAudio is loaded to rely on `systemctl` instead of starting it directly, this is a more idiomatic approach and may reduce conflicts if PulseAudio crashes. 